### PR TITLE
Skip Relativity Migration

### DIFF
--- a/db/migrate/20141226215527_create_drivers.rb
+++ b/db/migrate/20141226215527_create_drivers.rb
@@ -1,4 +1,6 @@
 class CreateDrivers < ActiveRecord::Migration
+  return if Rails.env == 'production'
+  
   using(:grossman)
 
   def change

--- a/db/migrate/20141226232633_create_trucking_drivers_views.rb
+++ b/db/migrate/20141226232633_create_trucking_drivers_views.rb
@@ -1,6 +1,8 @@
 class CreateTruckingDriversViews < ActiveRecord::Migration
+  return if Rails.env == 'production'
+  
   using(:grossman)
-
+  
   def up
     self.connection.execute 'CREATE OR REPLACE VIEW Trucking_Drivers AS
   SELECT

--- a/db/migrate/20141226232640_create_inventory_items.rb
+++ b/db/migrate/20141226232640_create_inventory_items.rb
@@ -1,4 +1,6 @@
 class CreateInventoryItems < ActiveRecord::Migration
+  return if Rails.env == 'production'
+  
   using(:grossman)
   
   def change

--- a/db/migrate/20141226232641_create_inventory_item_views.rb
+++ b/db/migrate/20141226232641_create_inventory_item_views.rb
@@ -1,4 +1,6 @@
 class CreateInventoryItemViews < ActiveRecord::Migration
+  return if Rails.env == 'production'
+  
   using(:grossman)
 
   def up

--- a/db/migrate/20150106163800_create_driver_commission_histories.rb
+++ b/db/migrate/20150106163800_create_driver_commission_histories.rb
@@ -1,4 +1,6 @@
 class CreateDriverCommissionHistories < ActiveRecord::Migration
+  return if Rails.env == 'production'
+  
   using(:grossman)
   def change
     create_table :driver_commission_histories do |t|

--- a/db/migrate/20150107233844_create_trucking_drivers_commissions_history_views.rb
+++ b/db/migrate/20150107233844_create_trucking_drivers_commissions_history_views.rb
@@ -1,4 +1,6 @@
 class CreateTruckingDriversCommissionsHistoryViews < ActiveRecord::Migration
+  return if Rails.env == 'production'
+  
   using(:grossman)
 
   def up

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,6 @@
 -- MySQL dump 10.15  Distrib 10.0.15-MariaDB, for osx10.10 (x86_64)
 --
--- Host: localhost    Database: gman_services_test
+-- Host: localhost    Database: gman_services_dev
 -- ------------------------------------------------------
 -- Server version	10.0.15-MariaDB
 
@@ -131,8 +131,18 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2015-01-30 12:20:13
+-- Dump completed on 2015-02-06 11:55:04
+INSERT INTO schema_migrations (version) VALUES ('20141226232633');
+
+INSERT INTO schema_migrations (version) VALUES ('20141226232640');
+
+INSERT INTO schema_migrations (version) VALUES ('20141226232641');
+
+INSERT INTO schema_migrations (version) VALUES ('20150106163800');
+
 INSERT INTO schema_migrations (version) VALUES ('20150106164711');
+
+INSERT INTO schema_migrations (version) VALUES ('20150107233844');
 
 INSERT INTO schema_migrations (version) VALUES ('20150107233845');
 


### PR DESCRIPTION
Rake db:migration does not occur when Rails Environment is production.