### PR TITLE
Driver commissions with invalid customers

### DIFF
--- a/app/models/driver_commission_history.rb
+++ b/app/models/driver_commission_history.rb
@@ -10,14 +10,11 @@ class DriverCommissionHistory < ActiveRecord::Base
 
   def self.default_scope
     includes(:customer, :driver, :movement_type)
-      .joins(:customer, :driver, :movement_type)
+      .joins(:driver, :movement_type)
   end
 
   def self.column_names
     %w{
-      CustomerId
-      MovementCd
-      DriverId
       Backhauls
       FreightRevenue
       DeliveryDate

--- a/app/views/api/v1/trucking/driver_commissions_history/index.json.jbuilder
+++ b/app/views/api/v1/trucking/driver_commissions_history/index.json.jbuilder
@@ -1,7 +1,12 @@
 json.array! commissions do |commission|
   json.back_hauls commission.Backhauls
-  json.customer_id commission.CustomerId
-  json.customer_name commission.customer.Name.strip
+  if commission.customer
+    json.customer_id commission.CustomerId
+    json.customer_name commission.customer.Name.strip
+  else
+    json.customer_id nil
+    json.customer_name nil
+  end
   json.delivery_date commission.DeliveryDate.to_s(:iso8601)
   json.driver_name commission.driver.name
   json.driver_number commission.DriverId.to_i


### PR DESCRIPTION
Update the driver commission history model to just include the customer
so it is a left join which will handle funny (non customer id) data
in the CustomerId of the Trucking_Drivers_Commissions_History schema.

This could be specific to our (Western Milling) Grossman/Relativity
schemas but for our use this isn't a problem for now.

Closes #61