### PR TITLE
Run migrations during deploy [TP#563]

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -3,7 +3,7 @@ require 'capistrano/deploy'
 require 'capistrano/bundler'
 require 'capistrano/puma'
 require 'capistrano/rails/assets'
-# require 'capistrano/rails/migrations'
+require 'capistrano/rails/migrations'
 require 'capistrano/rvm'
 require 'rollbar/capistrano3'
 


### PR DESCRIPTION
Enable active record migrations during capistrano deployment to make
sure the db is upto date. Whilst technically there should not actually
be any migrations to run against Grossman in staging or production
environments we still need the migrations to update the schema
versions table.

https://westernmilling.tpondemand.com/entity/563