### PR TITLE
Fix issue with remote logger (papertrail) ID:576

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../remote_logger.rb', __FILE__)
+
 Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,3 @@
-require File.expand_path('../remote_logger.rb', __FILE__)
-
 Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../remote_logger.rb', __FILE__)
+require_relative 'remote_logger'
 
 Rails.application.configure do
   config.action_controller.perform_caching = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require File.expand_path('../remote_logger.rb', __FILE__)
 
 Rails.application.configure do
   config.action_controller.perform_caching = true

--- a/config/environments/remote_logger.rb
+++ b/config/environments/remote_logger.rb
@@ -12,5 +12,4 @@ Rails.application.configure do
 
   config.log_formatter = ::Logger::Formatter.new
   config.log_level = (Figaro.env.REMOTE_LOG_LEVEL || 'info').to_sym
-  config.logger = logger
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../remote_logger.rb', __FILE__)
+require_relative 'remote_logger'
 
 Rails.application.configure do
   config.action_controller.perform_caching = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require File.expand_path('../remote_logger.rb', __FILE__)
 
 Rails.application.configure do
   config.action_controller.perform_caching = false


### PR DESCRIPTION
Fixed the issue with remote logger. When the config was extracted to logger.rb the require for it was `require 'logger'` which loaded the logger library and not the logger.rb file.

I renamed `logger.rb` to `remote_logger.rb` to prevent the wrong one from being loaded and changed the require.