### PR TITLE
Fix incorrect order status returned [TP#607]

### DIFF
--- a/app/views/api/v1/orders/_show.json.jbuilder
+++ b/app/views/api/v1/orders/_show.json.jbuilder
@@ -4,7 +4,7 @@ json.carrier_id order_reference.order.carrier_id
 json.quantity_shipped order_reference.order.quantity_shipped
 json.ship_date order_reference.ShipDate.to_date.to_s(:iso8601)
 json.ship_time order_reference.order.InOrd_ShipTime.strftime('%H:%M')
-json.status order_reference.status
+json.status order_reference.order.status
 json.warehouse_id order_reference.WarehouseId
 json.uuid order_reference.UuidHeader
 json.lines order_reference.order.lines do |order_line|


### PR DESCRIPTION
It would seem that Grossman does not update the order status field
in the InvCustomerOrders_CrossReference schema so this becomes out
of date and thus the Order::Reference status is incorrect.

To handle this the response has been updated to use the status
from the Order model (InvCustomerOrders_Open_MainInfo schema) which
is the up-to data order status.

https://westernmilling.tpondemand.com/entity/607