### PR TITLE
Include sales contract details with order [TP#644]

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -26,17 +26,41 @@ class Contract < ActiveRecord::Base
       CommodityId
       ContractId
       CommUOMId
-      CONT_ContractNumber
-      CONT_ContractType
+      LocationId
       CONT_ContractDate
-      CONT_Quantity
+      CONT_ContractNumber
+      CONT_ContractSub
+      CONT_ContractType
       CONT_DeliveredBushels
-      CONT_Price
       CONT_FreightAdjustment
+      CONT_Quantity
+      CONT_Price
       CONT_FromDate
       CONT_ToDate
+      Inv_ContractId
     }
   end
+
+  # def self.column_names
+  #   %w{
+  #     CustomerId
+  #     CommodityId
+  #     ContractId
+  #     CommUOMId
+  #     LocationId
+  #     CONT_ContractDate
+  #     CONT_ContractNumber
+  #     CONT_ContractSub
+  #     CONT_ContractType
+  #     CONT_Quantity
+  #     CONT_DeliveredBushels
+  #     CONT_Price
+  #     CONT_FreightAdjustment
+  #     CONT_FromDate
+  #     CONT_ToDate
+  #     Inv_ContractId
+  #   }
+  # end
 
   def self.ransackable_scopes(_auth_object = nil)
     [:commodity_id_eq, :customer_id_eq]

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -33,8 +33,8 @@ class Contract < ActiveRecord::Base
       CONT_ContractType
       CONT_DeliveredBushels
       CONT_FreightAdjustment
-      CONT_Quantity
       CONT_Price
+      CONT_Quantity
       CONT_FromDate
       CONT_ToDate
       Inv_ContractId

--- a/app/models/order/line.rb
+++ b/app/models/order/line.rb
@@ -5,6 +5,15 @@ class Order
     self.primary_key = 'OrderKey'
     self.table_name = 'InvCustomerOrders_Open_Detail'
 
+    def contract
+      return nil if self.ContractId == '00000000'
+
+      @contract ||= Contract
+        .where(CONT_ContractType: 'S', Inv_ContractId: self.ContractId)
+        .to_a
+        .first
+    end
+
     def self.default_scope
       select(column_names.map(&:to_s))
     end
@@ -14,6 +23,7 @@ class Order
         ItemId
         InOrd_QtyShipped
         InOrd_TotalPrice
+        ContractId
       }
     end
   end

--- a/app/models/order/line.rb
+++ b/app/models/order/line.rb
@@ -9,9 +9,12 @@ class Order
       return nil if self.ContractId == '00000000'
 
       @contract ||= Contract
-        .where(CONT_ContractType: 'S', Inv_ContractId: self.ContractId)
-        .to_a
-        .first
+                    .where(
+                      CONT_ContractType: 'S',
+                      Inv_ContractId: self.ContractId
+                    )
+                    .to_a
+                    .first
     end
 
     def self.default_scope

--- a/app/views/api/v1/orders/_show.json.jbuilder
+++ b/app/views/api/v1/orders/_show.json.jbuilder
@@ -14,6 +14,12 @@ json.lines order_reference.order.lines do |order_line|
   json.contract do
     if order_line.contract
       json.contract_id order_line.contract.ContractId
+      json.contract_date order_line.contract.CONT_ContractDate
+      json.contract_price order_line.contract.CONT_Price.to_f
+      json.contract_number order_line.contract.CONT_ContractNumber
+      json.contract_sub order_line.contract.CONT_ContractSub
+      json.contract_type order_line.contract.CONT_ContractType
+      json.location_id order_line.contract.LocationId
     else
       json.nil!
     end

--- a/app/views/api/v1/orders/_show.json.jbuilder
+++ b/app/views/api/v1/orders/_show.json.jbuilder
@@ -1,3 +1,4 @@
+json.ignore_nil!
 json.order_number order_reference.OrderNumber
 json.order_key order_reference.FeedXrefKey
 json.carrier_id order_reference.order.carrier_id
@@ -10,4 +11,11 @@ json.uuid order_reference.UuidHeader
 json.lines order_reference.order.lines do |order_line|
   json.item_number order_line.ItemId.strip
   json.item_price order_line.InOrd_TotalPrice
+  json.contract do
+    if order_line.contract
+      json.contract_id order_line.contract.ContractId
+    else
+      json.nil!
+    end
+  end
 end

--- a/db/migrate/20161205224535_add_contract_id_to_order_lines.rb
+++ b/db/migrate/20161205224535_add_contract_id_to_order_lines.rb
@@ -1,0 +1,15 @@
+class AddContractIdToOrderLines < ActiveRecord::Migration
+  def change
+    return if Order::Line
+              .connection
+              .class
+              .to_s
+              .include?('Relativity')
+
+    @connection = Order::Line.connection
+
+    add_column :InvCustomerOrders_Open_Detail,
+               :ContractId,
+               :string
+  end
+end

--- a/db/migrate/20161205224613_add_location_id_to_contracts.rb
+++ b/db/migrate/20161205224613_add_location_id_to_contracts.rb
@@ -1,0 +1,15 @@
+class AddLocationIdToContracts < ActiveRecord::Migration
+  def change
+    return if Contract
+              .connection
+              .class
+              .to_s
+              .include?('Relativity')
+
+    @connection = Contract.connection
+
+    add_column :Contract,
+               :LocationId,
+               :string
+  end
+end

--- a/db/migrate/20161205224648_add_inv_contract_id_to_contracts.rb
+++ b/db/migrate/20161205224648_add_inv_contract_id_to_contracts.rb
@@ -1,0 +1,15 @@
+class AddInvContractIdToContracts < ActiveRecord::Migration
+  def change
+    return if Contract
+              .connection
+              .class
+              .to_s
+              .include?('Relativity')
+
+    @connection = Contract.connection
+
+    add_column :Contract,
+               :Inv_ContractId,
+               :string
+  end
+end

--- a/db/migrate/20161205234249_add_order_key_to_order_lines.rb
+++ b/db/migrate/20161205234249_add_order_key_to_order_lines.rb
@@ -1,0 +1,16 @@
+class AddOrderKeyToOrderLines < ActiveRecord::Migration
+  def change
+    return if Order::Line
+              .connection
+              .class
+              .to_s
+              .include?('Relativity')
+
+    @connection = Order::Line.connection
+
+    add_column :InvCustomerOrders_Open_Detail,
+               :OrderKey,
+               :string,
+               null: false
+  end
+end

--- a/db/migrate/20161206001158_add_contract_sub_to_contracts.rb
+++ b/db/migrate/20161206001158_add_contract_sub_to_contracts.rb
@@ -1,0 +1,15 @@
+class AddContractSubToContracts < ActiveRecord::Migration
+  def change
+    return if Contract
+              .connection
+              .class
+              .to_s
+              .include?('Relativity')
+
+    @connection = Contract.connection
+
+    add_column :Contract,
+               :CONT_ContractSub,
+               :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161005215829) do
+ActiveRecord::Schema.define(version: 20161206001158) do
 
   create_table "oauth_access_grants", force: true do |t|
     t.integer  "resource_owner_id", null: false

--- a/spec/factories/contracts.rb
+++ b/spec/factories/contracts.rb
@@ -4,7 +4,9 @@ FactoryGirl.define do
     association :customer
     association :unit_of_measure, factory: :commodity_unit_of_measure
     sequence(:CONT_ContractNumber) { |x| 100_000 + x }
+    sequence(:LocationId) { |x| x }
     CONT_ContractDate { Date.current }
+    CONT_ContractSub { '00' }
     CONT_ContractType { %w{P S}.sample }
     CONT_Quantity { [50_000, 100_000].sample }
     CONT_DeliveredBushels { Faker::Number.between(0, self.CONT_Quantity) }
@@ -12,6 +14,14 @@ FactoryGirl.define do
     CONT_FromDate { Date.current }
     CONT_ToDate { Date.current + 1.year }
     CONT_Price { Faker::Number.between(200, 400) }
-    ContractId { "000#{self.CONT_ContractNumber}#{self.CONT_ContractType}" }
+    ContractId do
+      %W(
+        00
+        #{self.CONT_ContractNumber}
+        #{self.CONT_ContractSub}
+        #{self.CONT_ContractType}
+      ).join
+    end
+    Inv_ContractId { "#{self.CONT_ContractNumber}#{self.CONT_ContractSub}" }
   end
 end

--- a/spec/factories/order_lines.rb
+++ b/spec/factories/order_lines.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :order_line, class: 'Order::Line' do
+    sequence(:OrderKey) { |x| 1_000_000 + x }
     InOrd_QtyShipped { 0 }
   end
 end

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -30,15 +30,18 @@ RSpec.describe Contract, type: :model do
           CommodityId
           ContractId
           CommUOMId
-          CONT_ContractNumber
-          CONT_ContractType
+          LocationId
           CONT_ContractDate
-          CONT_Quantity
+          CONT_ContractNumber
+          CONT_ContractSub
+          CONT_ContractType
           CONT_DeliveredBushels
-          CONT_Price
           CONT_FreightAdjustment
+          CONT_Price
+          CONT_Quantity
           CONT_FromDate
           CONT_ToDate
+          Inv_ContractId
         }
       )
     end

--- a/spec/requests/api/v1/order_request_spec.rb
+++ b/spec/requests/api/v1/order_request_spec.rb
@@ -111,9 +111,10 @@ describe '/api/v1/orders' do
                   end
                 end
 
-                it { puts "Line: #{response_body['lines'][0]}"; is_expected.to be_present }
+                it { is_expected.to be_present }
                 its(['contract_date']) do
-                  is_expected.to eq order_line.contract.CONT_ContractDate
+                  is_expected
+                    .to eq order_line.contract.CONT_ContractDate.to_s(:iso8601)
                 end
                 its(['contract_id']) do
                   is_expected.to eq order_line.contract.ContractId


### PR DESCRIPTION
Include some basic sale contract details in the order response so
that consumers know which sales contract was applied to the order
to determine pricing.

https://westernmilling.tpondemand.com/entity/644