### PR TITLE
Add missing fields to contract response [TP#887]

### DIFF
--- a/app/views/api/v1/commodity_merchandising/contracts/index.json.jbuilder
+++ b/app/views/api/v1/commodity_merchandising/contracts/index.json.jbuilder
@@ -2,6 +2,8 @@ json.array! contracts do |contract|
   json.contract_id contract.ContractId
   json.customer_id contract.CustomerId.to_i
   json.commodity_id contract.CommodityId.to_i
+  json.inv_contract_id contract.Inv_ContractId
+  json.location_id contract.LocationId.to_i
   json.contract_number contract.CONT_ContractNumber
   json.price contract.CONT_Price.to_f
   json.freight_adjustment contract.CONT_FreightAdjustment.to_f
@@ -15,7 +17,7 @@ json.array! contracts do |contract|
     json.description contract.unit_of_measure.CommUOMDescription.strip
   end
   json.contract_date contract.CONT_ContractDate
-  json.contract_type contract.CONT_ContractType
+  json.contract_type contract.contract_type
   json.quantity contract.CONT_Quantity.to_f
   json.delivered_quantity contract.CONT_DeliveredBushels.to_f
   json.from_date contract.CONT_FromDate

--- a/spec/requests/api/v1/commodity_merchandising/contracts_spec.rb
+++ b/spec/requests/api/v1/commodity_merchandising/contracts_spec.rb
@@ -48,7 +48,13 @@ RSpec.describe '/api/v1/commodity_merchandising/contracts', type: :request do
           is_expected.to eq contracts[0].CONT_ContractDate.to_s(:iso8601)
         end
         its(['contract_type']) do
-          is_expected.to eq contracts[0].CONT_ContractType
+          is_expected.to eq contracts[0].contract_type
+        end
+        its(['inv_contract_id']) do
+          is_expected.to eq contracts[0].Inv_ContractId
+        end
+        its(['location_id']) do
+          is_expected.to eq contracts[0].LocationId
         end
         its(['price']) do
           is_expected.to eq contracts[0].CONT_Price


### PR DESCRIPTION
The contract response is missing the location which is pretty crucial
for contract uniqueness, and there is no inv contract id which is
a convenience composite of contract number and sub.

Also, the contract type is using the old single character and not the
more verbose value.

https://westernmilling.tpondemand.com/entity/887