### PR TITLE
Fix contract parameter type mismatch [TP#895]

### DIFF
--- a/app/models/concerns/contract.rb
+++ b/app/models/concerns/contract.rb
@@ -49,13 +49,13 @@ class Contract < ActiveRecord::Base
       scope :commodity_id_eq,
             ->(value) { where("Contract.CommodityId = #{value}") }
       scope :contract_type_eq,
-            ->(value) { where("Contract.CONT_ContractType = '#{value}'") }
+            ->(value) { where("Contract.CONT_ContractType = ?", value) }
       scope :customer_id_eq,
-            ->(value) { where("Contract.CustomerId = '#{value}'") }
+            ->(value) { where("Contract.CustomerId = ?", value) }
       scope :inv_contract_id_eq,
-            ->(value) { where("Contract.Inv_ContractId = '#{value}'") }
-      scope :location_id_eq,
-            ->(value) { where("Contract.LocationId = #{value}") }
+            ->(value) { where("Contract.Inv_ContractId = ?", value) }
+            scope :location_id_eq,
+                  ->(value) { where("Contract.LocationId = #{value}") }
     end
   end
 end

--- a/app/models/concerns/contract.rb
+++ b/app/models/concerns/contract.rb
@@ -53,7 +53,7 @@ class Contract < ActiveRecord::Base
       scope :customer_id_eq,
             ->(value) { where("Contract.CustomerId = '#{value}'") }
       scope :inv_contract_id_eq,
-            ->(value) { where("Contract.Inv_ContractId = #{value}") }
+            ->(value) { where("Contract.Inv_ContractId = '#{value}'") }
       scope :location_id_eq,
             ->(value) { where("Contract.LocationId = #{value}") }
     end

--- a/app/models/concerns/contract.rb
+++ b/app/models/concerns/contract.rb
@@ -49,13 +49,13 @@ class Contract < ActiveRecord::Base
       scope :commodity_id_eq,
             ->(value) { where("Contract.CommodityId = #{value}") }
       scope :contract_type_eq,
-            ->(value) { where("Contract.CONT_ContractType = ?", value) }
+            ->(value) { where('Contract.CONT_ContractType = ?', value) }
       scope :customer_id_eq,
-            ->(value) { where("Contract.CustomerId = ?", value) }
+            ->(value) { where('Contract.CustomerId = ?', value) }
       scope :inv_contract_id_eq,
-            ->(value) { where("Contract.Inv_ContractId = ?", value) }
-            scope :location_id_eq,
-                  ->(value) { where("Contract.LocationId = #{value}") }
+            ->(value) { where('Contract.Inv_ContractId = ?', value) }
+      scope :location_id_eq,
+            ->(value) { where("Contract.LocationId = #{value}") }
     end
   end
 end

--- a/db/seeds/development/driver_and_driver_commission_histories.seeds.rb
+++ b/db/seeds/development/driver_and_driver_commission_histories.seeds.rb
@@ -8,7 +8,7 @@ movement_type = FactoryGirl.create(:movement_type)
   driver.save
   FactoryGirl.create(:driver_commission_history,
                      DriverId: driver.id,
-                     CustomerName: customer.customer_name,
-                     CustomerId: customer.customer_id,
-                     MovementCd: movement_type.movement_cd)
+                     CustomerName: customer.Name,
+                     CustomerId: customer.CustomerId,
+                     MovementCd: movement_type.MovementCd)
 end


### PR DESCRIPTION
Update the contract scope SQL to wrap inventory contract id values
in single quotes as this is a string field in Grossman/Relativity.

This would not fail when testing with local (non Relativity) datasources
since they perform implicit type conversion so `SELECT 1 == '1'` is true,
however this is not the case for Relativity. For now I propose additional
pre merge tests against a Relativity datasource.

https://westernmilling.tpondemand.com/entity/895