### PR TITLE
Filter pick up orders by status [TP#934]

### DIFF
--- a/app/models/concerns/pick_up_order.rb
+++ b/app/models/concerns/pick_up_order.rb
@@ -50,7 +50,8 @@ class PickUpOrder < ActiveRecord::Base
           :purchase_customer_id_eq,
           :release_prefix_eq,
           :release_load_number_eq,
-          :release_number_eq
+          :release_number_eq,
+          :status_eq
         ]
       end
     end
@@ -109,6 +110,10 @@ class PickUpOrder < ActiveRecord::Base
           load_number = value.slice(-4, 4)
 
           release_prefix_eq(prefix).release_load_number_eq(load_number)
+        end
+
+        def status_eq(value)
+          where("Status = #{value}")
         end
       end
     end

--- a/docs/api/v1/README.md
+++ b/docs/api/v1/README.md
@@ -206,6 +206,7 @@ Fetch pick up orders by filter.
   number. The release prefix should be padded to 10 characters and the release
   load number should be padded to 4 zeros. For example:
     `TEST______0001`
+* q\[status_eq\](number): 0 for Open, 1 for Used.
 
 ```bash
 curl -H "Authorization: Bearer {token}"

--- a/spec/requests/api/v1/pick_up_orders_spec.rb
+++ b/spec/requests/api/v1/pick_up_orders_spec.rb
@@ -180,7 +180,7 @@ describe 'pick up orders' do
         expect(
           parsed_body
             .map { |hash| "#{hash['contract_id']}-#{hash['load_number']}" }
-        ).to include(
+        ).to contain_exactly(
           *matching_pick_up_orders
             .map { |match| "#{match.ContractId}-#{match.LoadNumber}" }
         )
@@ -220,7 +220,7 @@ describe 'pick up orders' do
         expect(
           parsed_body
             .map { |hash| "#{hash['contract_id']}-#{hash['load_number']}" }
-        ).to include(
+        ).to contain_exactly(
           *matching_pick_up_orders
             .map { |match| "#{match.ContractId}-#{match.LoadNumber}" }
         )
@@ -260,7 +260,7 @@ describe 'pick up orders' do
         expect(
           parsed_body
             .map { |hash| "#{hash['contract_id']}-#{hash['load_number']}" }
-        ).to include(
+        ).to contain_exactly(
           *matching_pick_up_orders
             .map { |match| "#{match.ContractId}-#{match.LoadNumber}" }
         )
@@ -279,7 +279,50 @@ describe 'pick up orders' do
 
         expect(parsed_body).to_not be_empty
         expect(parsed_body.map { |hash| hash['contract_balance'] })
-          .to_not include filters[:contract_balance_not_eq].to_i
+          .to_not contain_exactly filters[:contract_balance_not_eq].to_i
+      end
+    end
+
+    context 'when the request is filtering by open status' do
+      let(:pick_up_orders) do
+        [
+          create(:pick_up_order,
+                 ContractId: contracts[0].Inv_ContractId,
+                 ContractLocationId: contracts[0].LocationId,
+                 ItemId: items[0].ItemId,
+                 LoadNumber: 1,
+                 PurchaseCustomerId: contracts[0].CustomerId,
+                 ReleasePrefix: contracts[0].Inv_ContractId,
+                 ReleaseLoadNumber: 1,
+                 Status: 0),
+          create(:pick_up_order,
+                 ContractId: contracts[1].Inv_ContractId,
+                 ContractLocationId: contracts[1].LocationId,
+                 ItemId: items[0].ItemId,
+                 LoadNumber: 1,
+                 PurchaseCustomerId: contracts[1].CustomerId,
+                 ReleasePrefix: contracts[1].Inv_ContractId,
+                 ReleaseLoadNumber: 1,
+                 Status: 1)
+        ]
+      end
+      let(:filters) do
+        {
+          status_eq: 0
+        }
+      end
+
+      it 'should only not return matching records' do
+        parsed_body = JSON.parse(response.body)
+
+        expect(parsed_body).to_not be_empty
+        expect(
+          parsed_body
+            .map { |hash| "#{hash['contract_id']}-#{hash['load_number']}" }
+        ).to contain_exactly(
+          *[pick_up_orders[0]]
+            .map { |match| "#{match.ContractId}-#{match.LoadNumber}" }
+        )
       end
     end
   end


### PR DESCRIPTION
Allow clients to include a status filter when fetching pick up orders.

https://westernmilling.tpondemand.com/entity/934