### PR TITLE
Filter pick up orders by ItemId [TP#949]

### DIFF
--- a/app/models/concerns/pick_up_order.rb
+++ b/app/models/concerns/pick_up_order.rb
@@ -47,6 +47,7 @@ class PickUpOrder < ActiveRecord::Base
           :contract_id_eq,
           :contract_present,
           :item_commodity_id_eq,
+          :item_id_eq,
           :purchase_customer_id_eq,
           :release_prefix_eq,
           :release_load_number_eq,
@@ -91,6 +92,10 @@ class PickUpOrder < ActiveRecord::Base
 
         def item_commodity_id_eq(value)
           where("InvItems.InItem_CommodityId = #{value}")
+        end
+
+        def item_id_eq(value)
+          where('InvPickUpOrders.ItemId = ?', value)
         end
 
         def purchase_customer_id_eq(value)

--- a/app/models/concerns/pick_up_order.rb
+++ b/app/models/concerns/pick_up_order.rb
@@ -95,7 +95,7 @@ class PickUpOrder < ActiveRecord::Base
         end
 
         def item_id_eq(value)
-          where('InvPickUpOrders.ItemId = ?', value)
+          where('InvItems.ItemId = ?', value)
         end
 
         def purchase_customer_id_eq(value)

--- a/docs/api/v1/README.md
+++ b/docs/api/v1/README.md
@@ -202,6 +202,7 @@ Fetch pick up orders by filter.
 ##### params
 * q\[contract_id_eq\](string)
 * q\[item_commodity_id_eq\](number)
+* q\[item_id_eq\](string)
 * q\[purchase_customer_id_eq\](string)
 * q\[release_prefix_eq\](string)
 * q\[release_load_number_eq\]

--- a/spec/factories/pick_up_orders.rb
+++ b/spec/factories/pick_up_orders.rb
@@ -1,10 +1,12 @@
 FactoryGirl.define do
   factory :pick_up_order do
     sequence(:CarrierCustomerNumber) { |x| 1_000 + x }
+    sequence(:ContractId) { |x| 100_000 + x }
     sequence(:ItemId) { |x| 10 + x }
 
     CarrierCustomerSub { '00' }
     FreightAmount { 0 }
+    LoadNumber { 1 }
     Origin { Faker::Address.city }
     OriginState { Faker::Address.state }
     OriginWeightCertificate { 0 }

--- a/spec/models/pick_up_order_spec.rb
+++ b/spec/models/pick_up_order_spec.rb
@@ -98,4 +98,35 @@ RSpec.describe PickUpOrder, type: :model do
       )
     end
   end
+
+  describe '.item_id_eq' do
+    before do
+      subject_pool
+    end
+
+    let(:subject_pool) do
+      Array.new(4) do |index|
+        create(:pick_up_order, ItemId: (1 + (index % 2)).to_s)
+      end
+    end
+
+    subject { described_class.item_id_eq(item_id) }
+
+    context 'when there are matching records' do
+      let(:item_id) { '1' }
+
+      it 'should return matches' do
+        expect(subject).to_not be_empty
+        expect(subject.map(&:ItemId)).to all eq item_id
+      end
+    end
+
+    context 'when there are no matching records' do
+      let(:item_id) { '99' }
+
+      it 'should return nothing' do
+        expect(subject).to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/pick_up_order_spec.rb
+++ b/spec/models/pick_up_order_spec.rb
@@ -104,25 +104,70 @@ RSpec.describe PickUpOrder, type: :model do
       subject_pool
     end
 
+    let(:matching_item) { create(:inventory_item, ItemId: '1000') }
+    let(:matching_pool) do
+      create_list(:pick_up_order, 2, item: matching_item)
+    end
     let(:subject_pool) do
-      Array.new(4) do |index|
-        create(:pick_up_order, ItemId: (1 + (index % 2)).to_s)
-      end
+      matching_pool + create_list(:pick_up_order, 2, ItemId: '2000')
     end
 
     subject { described_class.item_id_eq(item_id) }
 
     context 'when there are matching records' do
-      let(:item_id) { '1' }
+      let(:item_id) { '1000' }
 
       it 'should return matches' do
-        expect(subject).to_not be_empty
-        expect(subject.map(&:ItemId)).to all eq item_id
+        expect(
+          subject
+            .map { |object| "#{object.ContractId}-#{object.LoadNumber}" }
+        ).to contain_exactly(
+          *matching_pool
+            .map { |object| "#{object.ContractId}-#{object.LoadNumber}" }
+        )
       end
     end
 
     context 'when there are no matching records' do
       let(:item_id) { '99' }
+
+      it 'should return nothing' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+
+  describe '.status_eq' do
+    before do
+      subject_pool
+    end
+
+    let(:matching_pool) do
+      create_list(:pick_up_order, 2, Status: 0)
+    end
+    let(:subject_pool) do
+      matching_pool + create_list(:pick_up_order, 2, Status: 1)
+    end
+
+    subject { described_class.status_eq(status) }
+
+    context 'when there are matching records' do
+      let(:status) { 0 }
+
+      it 'should return matches' do
+        expect(
+          subject
+            .map { |object| "#{object.ContractId}-#{object.LoadNumber}" }
+        ).to contain_exactly(
+          *matching_pool
+            .map { |object| "#{object.ContractId}-#{object.LoadNumber}" }
+        )
+      end
+    end
+
+    context 'when there are no matching records' do
+      let(:matching_pool) { [] }
+      let(:status) { 0 }
 
       it 'should return nothing' do
         expect(subject).to be_empty

--- a/spec/requests/api/v1/pick_up_orders_spec.rb
+++ b/spec/requests/api/v1/pick_up_orders_spec.rb
@@ -282,48 +282,5 @@ describe 'pick up orders' do
           .to_not contain_exactly filters[:contract_balance_not_eq].to_i
       end
     end
-
-    context 'when the request is filtering by open status' do
-      let(:pick_up_orders) do
-        [
-          create(:pick_up_order,
-                 ContractId: contracts[0].Inv_ContractId,
-                 ContractLocationId: contracts[0].LocationId,
-                 ItemId: items[0].ItemId,
-                 LoadNumber: 1,
-                 PurchaseCustomerId: contracts[0].CustomerId,
-                 ReleasePrefix: contracts[0].Inv_ContractId,
-                 ReleaseLoadNumber: 1,
-                 Status: 0),
-          create(:pick_up_order,
-                 ContractId: contracts[1].Inv_ContractId,
-                 ContractLocationId: contracts[1].LocationId,
-                 ItemId: items[0].ItemId,
-                 LoadNumber: 1,
-                 PurchaseCustomerId: contracts[1].CustomerId,
-                 ReleasePrefix: contracts[1].Inv_ContractId,
-                 ReleaseLoadNumber: 1,
-                 Status: 1)
-        ]
-      end
-      let(:filters) do
-        {
-          status_eq: 0
-        }
-      end
-
-      it 'should only not return matching records' do
-        parsed_body = JSON.parse(response.body)
-
-        expect(parsed_body).to_not be_empty
-        expect(
-          parsed_body
-            .map { |hash| "#{hash['contract_id']}-#{hash['load_number']}" }
-        ).to contain_exactly(
-          *[pick_up_orders[0]]
-            .map { |match| "#{match.ContractId}-#{match.LoadNumber}" }
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
Allow filtering pick up order by the ItemId as we'll want to allow
consumers to fetch pick up order by item.

Test the model rather than the request since we really don't need
the overhead of the request with each new filtering method. At some
point we should probably move most of the filtering examples from the
request tests into the model tests.

https://westernmilling.tpondemand.com/entity/949