### PR TITLE
Record exceptions as health check failures ID:2319

### DIFF
--- a/app/controllers/api/v1/health_check_controller.rb
+++ b/app/controllers/api/v1/health_check_controller.rb
@@ -9,6 +9,8 @@ module Api
         else
           render json: { health_check: 'Failed' }, status: 500
         end
+      rescue ActiveRecord::JDBCError
+        render json: { health_check: 'Failed' }, status: 500
       end
     end
   end

--- a/spec/controllers/api/v1/health_check_controller_spec.rb
+++ b/spec/controllers/api/v1/health_check_controller_spec.rb
@@ -72,5 +72,19 @@ RSpec.describe Api::V1::HealthCheckController, type: :controller do
         expect(parsed_json['health_check']).to eq('Failed')
       end
     end
+
+    context 'a ActiveRecord::JDBCError is raised' do
+      before do
+        allow(Customer)
+          .to receive(:count)
+          .and_raise(ActiveRecord::JDBCError)
+
+        get :index
+      end
+
+      it 'fails the health check' do
+        expect(JSON.parse(response.body)['health_check']).to eq('Failed')
+      end
+    end
   end
 end


### PR DESCRIPTION
https://westernmilling.tpondemand.com/entity/2319

Rescues exceptions:

-
[ActiveRecord::JDBCError](https://rollbar.com/westernmilling/gman-services/items/117/)