### PR TITLE
Story/fix relativity timeout 2349

### DIFF
--- a/app/controllers/api/v1/health_check_controller.rb
+++ b/app/controllers/api/v1/health_check_controller.rb
@@ -1,15 +1,20 @@
+require 'timeout'
+
+# rubocop:disable ColonMethodCall
 module Api
   module V1
     class HealthCheckController < Api::BaseController
       def index
-        result = Customer.count
+        result = Timeout::timeout(20) do
+          Customer.count
+        end
 
         if result
           render json: { health_check: 'Passed' }
         else
           render json: { health_check: 'Failed' }, status: 500
         end
-      rescue ActiveRecord::JDBCError
+      rescue ActiveRecord::JDBCError, ActiveRecord::ConnectionTimeoutError
         render json: { health_check: 'Failed' }, status: 500
       end
     end

--- a/spec/controllers/api/v1/health_check_controller_spec.rb
+++ b/spec/controllers/api/v1/health_check_controller_spec.rb
@@ -86,5 +86,19 @@ RSpec.describe Api::V1::HealthCheckController, type: :controller do
         expect(JSON.parse(response.body)['health_check']).to eq('Failed')
       end
     end
+
+    context 'a ActiveRecord::ConnectionTimeoutError is raised' do
+      before do
+        allow(Customer)
+          .to receive(:count)
+          .and_raise(ActiveRecord::ConnectionTimeoutError)
+
+        get :index
+      end
+
+      it 'fails the health check' do
+        expect(JSON.parse(response.body)['health_check']).to eq('Failed')
+      end
+    end
   end
 end


### PR DESCRIPTION
https://westernmilling.tpondemand.com/entity/2349

We seem to get these errors consistently when Relativity is down (or so slow as to appear down), so this change rescues them and reports it as a failed health check.

Also adds a timeout as spec'd in the story, but I could not find a way to test this even with Timecop. I did manually test that the timeout works.