### PR TITLE
Add Fob Location to contract API ID:3076

### DIFF
--- a/app/views/api/v1/commodity_merchandising/contracts/index.json.jbuilder
+++ b/app/views/api/v1/commodity_merchandising/contracts/index.json.jbuilder
@@ -22,6 +22,7 @@ json.array! contracts do |contract|
   end
   json.contract_date contract.CONT_ContractDate
   json.contract_type contract.contract_type
+  json.fob_location contract.fob_location
   json.quantity contract.CONT_Quantity.to_f
   json.delivered_quantity contract.CONT_DeliveredBushels.to_f
   json.from_date contract.CONT_FromDate

--- a/docs/api/v1/README.md
+++ b/docs/api/v1/README.md
@@ -86,6 +86,7 @@ Returns matching contracts.
     "contract_type": "Purchase",
     "quantity": 1000000,
     "delivered_quantity": 0,
+    "fob_location": "Delivered"
     "from_date": "2017-01-01",
     "to_date": "2017-01-31"
   }

--- a/spec/factories/contracts.rb
+++ b/spec/factories/contracts.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     CONT_ContractType { %w{P S}.sample }
     CONT_Quantity { [50_000, 100_000].sample }
     CONT_DeliveredBushels { Faker::Number.between(0, self.CONT_Quantity) }
+    CONT_FobLocationDescription1 { %w(D F).sample }
     CONT_FreightAdjustment { [0, 5, 6, 7].sample }
     CONT_FromDate { Date.current }
     CONT_ToDate { Date.current + 1.year }

--- a/spec/requests/api/v1/commodity_merchandising/contracts_spec.rb
+++ b/spec/requests/api/v1/commodity_merchandising/contracts_spec.rb
@@ -58,6 +58,9 @@ RSpec.describe '/api/v1/commodity_merchandising/contracts', type: :request do
         its(['contract_type']) do
           is_expected.to eq contracts[0].contract_type
         end
+        its(['fob_location']) do
+          is_expected.to eq contracts[0].fob_location
+        end
         its(['inv_contract_id']) do
           is_expected.to eq contracts[0].Inv_ContractId
         end


### PR DESCRIPTION
Add the Fob Location value to the contract API response so that
clients know if a contract is Delivered or FOB.

https://westernmilling.tpondemand.com/entity/3076