### PR TITLE
Add FOB Location to order contract info ID:3120

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - jruby-head
+  - jruby-9.0.5.0
 script:
   - bundle exec rake db:migrate RAILS_ENV=test
   - bundle exec rspec --color --format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: ruby
 rvm:
   - jruby-9.0.5.0

--- a/app/views/api/v1/orders/_show.json.jbuilder
+++ b/app/views/api/v1/orders/_show.json.jbuilder
@@ -25,6 +25,7 @@ json.lines order_reference.order.lines do |order_line|
       json.contract_number order_line.contract.CONT_ContractNumber
       json.contract_sub order_line.contract.CONT_ContractSub
       json.contract_type order_line.contract.contract_type
+      json.fob_location order_line.contract.fob_location
       json.location_id order_line.contract.LocationId
     end
   else

--- a/spec/requests/api/v1/order_request_spec.rb
+++ b/spec/requests/api/v1/order_request_spec.rb
@@ -144,6 +144,9 @@ describe '/api/v1/orders' do
                 its(['contract_type']) do
                   is_expected.to eq order_line.contract.contract_type
                 end
+                its(['fob_location']) do
+                  is_expected.to eq order_line.contract.fob_location
+                end
                 its(['location_id']) do
                   is_expected.to eq order_line.contract.LocationId
                 end


### PR DESCRIPTION
Add the FOB Location to the order contract details so that the order
sales contract isn't missing required information.

https://westernmilling.tpondemand.com/entity/3119