### PR TITLE
Add the missing contract sub ID:3265]

### DIFF
--- a/app/views/api/v1/commodity_merchandising/contracts/_show.json.jbuilder
+++ b/app/views/api/v1/commodity_merchandising/contracts/_show.json.jbuilder
@@ -8,6 +8,7 @@ json.commodity_id contract.CommodityId.to_i
 json.inv_contract_id contract.Inv_ContractId
 json.location_id contract.LocationId.to_i
 json.contract_number contract.CONT_ContractNumber
+json.contract_sub contract.CONT_ContractSub
 json.price contract.CONT_Price.to_f
 json.freight_adjustment contract.CONT_FreightAdjustment.to_f
 json.commodity do

--- a/spec/requests/api/v1/commodity_merchandising/contracts_spec.rb
+++ b/spec/requests/api/v1/commodity_merchandising/contracts_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe '/api/v1/commodity_merchandising/contracts', type: :request do
         its(['contract_number']) do
           is_expected.to eq contracts[0].CONT_ContractNumber
         end
+        its(['contract_sub']) do
+          is_expected.to eq contracts[0].CONT_ContractSub
+        end
         its(['commodity_id']) do
           is_expected.to eq contracts[0].CommodityId.to_i
         end

--- a/spec/requests/api/v1/order_request_spec.rb
+++ b/spec/requests/api/v1/order_request_spec.rb
@@ -136,6 +136,9 @@ describe '/api/v1/orders' do
                 its(['contract_number']) do
                   is_expected.to eq contract.CONT_ContractNumber
                 end
+                its(['contract_sub']) do
+                  is_expected.to eq contract.CONT_ContractSub
+                end
                 its(['commodity_id']) do
                   is_expected.to eq contract.CommodityId.to_i
                 end


### PR DESCRIPTION
For some reason the contract response never had the contract sub,
but the order contract response did. In using the contract view
for the order response we lost this and clients who depended on this
became unhappy... this puts it back so hopefully they will forgive
me.

https://westernmilling.tpondemand.com/entity/3265