### PR TITLE
Fix pick up order load number filter

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec bin/puma -C config/puma.rb
-log: tail -f log/development.log
+log: touch log/development.log && tail -f log/development.log

--- a/app/models/concerns/pick_up_order.rb
+++ b/app/models/concerns/pick_up_order.rb
@@ -100,7 +100,7 @@ class PickUpOrder < ActiveRecord::Base
         end
 
         def load_number_eq(value)
-          where('InvPickUpOrders.LoadNumber = ?', value)
+          where('InvPickUpOrders.LoadNumber = ?', value.to_i)
         end
 
         def purchase_customer_id_eq(value)


### PR DESCRIPTION
When passing a string value to the load_number_eq ransack filter
scope the query would fail with:

```
[Relativity JDBC Driver][SimbaLNA][Liant][Relativity Server]
Incompatible types in predicate.
```

This fix forces the filter value to an integer so the load number
is always queries by an integer.