### PR TITLE
Endpoint for contracts including pickup orders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM jruby:9.0.5.0
+
+WORKDIR /usr/src/app
+
+RUN apt-get update
+RUN apt-get install -y git
+
+COPY Gemfile* /usr/src/app/
+
+RUN bundle install
+
+COPY . /usr/src/app/
+
+CMD ["rails", "s", "-b", "0.0.0.0"]

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class BaseController < ApplicationController
-    # before_action :doorkeeper_authorize!
+    before_action :doorkeeper_authorize!
 
     respond_to :json
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class BaseController < ApplicationController
-    before_action :doorkeeper_authorize!
+    # before_action :doorkeeper_authorize!
 
     respond_to :json
 

--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -35,7 +35,9 @@ module Api
         end
 
         def customer_ids
-          params[:customer_ids]
+          params[:customer_ids].split(',').map do |customer_id|
+            "'#{customer_id}'"
+          end.join(',')
         end
       end
     end

--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -2,7 +2,9 @@ module Api
   module V1
     module CommodityMerchandising
       class BulkContractsController < Api::BaseController
-        include SimpleApi
+        def index
+          render json: resources, status: :ok
+        end
 
         private
 
@@ -19,7 +21,7 @@ module Api
           'INNER JOIN InvPickUpOrders on' \
           'InvPickUpOrders.ContractId = Contract.Inv_ContractId' \
           'and Contract.LocationId = InvPickUpOrders.ContractLocationId' \
-          "where CustomerId = '#{customer_ids}'"
+          "where CustomerId IN (#{customer_ids})"
         end
 
         def column_names
@@ -33,7 +35,7 @@ module Api
         end
 
         def customer_ids
-          params[:q][:customer_ids]
+          params[:customer_ids]
         end
       end
     end

--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -17,10 +17,10 @@ module Api
         end
 
         def search_query_string
-          "select #{column_names.join(', ')} from Contract" \
-          'INNER JOIN InvPickUpOrders on' \
-          'InvPickUpOrders.ContractId = Contract.Inv_ContractId' \
-          'and Contract.LocationId = InvPickUpOrders.ContractLocationId' \
+          "select #{column_names.join(', ')} from Contract " \
+          'INNER JOIN InvPickUpOrders on ' \
+          'InvPickUpOrders.ContractId = Contract.Inv_ContractId ' \
+          'and Contract.LocationId = InvPickUpOrders.ContractLocationId ' \
           "where CustomerId IN (#{customer_ids})"
         end
 

--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  module V1
+    module CommodityMerchandising
+      class BulkContractsController < Api::BaseController
+        include SimpleApi
+
+        private
+
+        def resources
+          @_resources ||= search.as_json(include: :pick_up_orders)
+        end
+
+        def search
+          Contract.connection.select(search_query_string).to_a
+        end
+
+        def search_query_string
+          "select #{column_names.join(', ')} from Contract" \
+          'INNER JOIN InvPickUpOrders on' \
+          'InvPickUpOrders.ContractId = Contract.Inv_ContractId' \
+          'and Contract.LocationId = InvPickUpOrders.ContractLocationId' \
+          "where CustomerId = '#{customer_ids}'"
+        end
+
+        def column_names
+          column_name_generator(Contract) + column_name_generator(PickUpOrder)
+        end
+
+        def column_name_generator(model_class)
+          model_class.column_names.map do |name|
+            "#{model_class.table_name}.#{name}"
+          end
+        end
+
+        def customer_ids
+          params[:q][:customer_ids]
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   scope '/api/v1', module: 'api/v1' do
     scope 'commodity_merchandising', module: 'commodity_merchandising' do
       resources :contracts, only: [:index], defaults: { format: 'json' }
+      resources :bulk_contracts, only: [:index], defaults: { format: 'json' }
     end
     get 'customer_contracts(.:format)',
         to: 'customer_contracts#index',


### PR DESCRIPTION
Add an endpoint for selecting contracts including their pick up orders.
This will enable much faster syncing of contracts to Otto.

Add a Dockerfile for running the application locally with Docker. 

needed-by #107