### PR TITLE
Remove customer ids filter from bulk contracts endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'jdbc-mysql', platform: :jruby
 gem 'jquery-rails'
 gem 'mysql2', platform: :ruby
 gem 'net-ssh', '2.9.2'
-gem 'oj'
 gem 'omniauth'
 gem 'omniauth-oauth2', '1.0.3'
 gem 'plissken', git: 'https://github.com/michaelachrisco/plissken.git',

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'jdbc-mysql', platform: :jruby
 gem 'jquery-rails'
 gem 'mysql2', platform: :ruby
 gem 'net-ssh', '2.9.2'
+gem 'oj'
 gem 'omniauth'
 gem 'omniauth-oauth2', '1.0.3'
 gem 'plissken', git: 'https://github.com/michaelachrisco/plissken.git',

--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -9,7 +9,7 @@ module Api
         private
 
         def resources
-          @_resources ||= search.as_json(include: :pick_up_orders)
+          @_resources ||= search
         end
 
         def search
@@ -20,8 +20,7 @@ module Api
           "select #{column_names.join(', ')} from Contract " \
           'INNER JOIN InvPickUpOrders on ' \
           'InvPickUpOrders.ContractId = Contract.Inv_ContractId ' \
-          'and Contract.LocationId = InvPickUpOrders.ContractLocationId ' \
-          "where CustomerId IN (#{customer_ids})"
+          'and Contract.LocationId = InvPickUpOrders.ContractLocationId'
         end
 
         def column_names
@@ -32,12 +31,6 @@ module Api
           model_class.column_names.map do |name|
             "#{model_class.table_name}.#{name}"
           end
-        end
-
-        def customer_ids
-          params[:customer_ids].split(',').map do |customer_id|
-            "'#{customer_id}'"
-          end.join(',')
         end
       end
     end

--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -3,17 +3,13 @@ module Api
     module CommodityMerchandising
       class BulkContractsController < Api::BaseController
         def index
-          render json: resources, status: :ok
+          render text: resources, status: :ok
         end
 
         private
 
         def resources
-          @_resources ||= search
-        end
-
-        def search
-          Contract.connection.select(search_query_string).to_a
+          Contract.connection.select(search_query_string).to_a.inspect
         end
 
         def search_query_string

--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -3,13 +3,14 @@ module Api
     module CommodityMerchandising
       class BulkContractsController < Api::BaseController
         def index
-          render json: resources, status: :ok
+          render text: resources, status: :ok
         end
 
         private
 
         def resources
           JSON.dump(records)
+        end
 
         def records
           Contract.connection.select(search_query_string).to_a

--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -3,13 +3,16 @@ module Api
     module CommodityMerchandising
       class BulkContractsController < Api::BaseController
         def index
-          render text: resources, status: :ok
+          render json: resources, status: :ok
         end
 
         private
 
         def resources
-          Contract.connection.select(search_query_string).to_a.inspect
+          JSON.dump(records)
+
+        def records
+          Contract.connection.select(search_query_string).to_a
         end
 
         def search_query_string


### PR DESCRIPTION
From testing found out that filtering by customer ids loses a
large number of contracts that we need. The call without customer
ids is similar in length but returns all of the contracts we need
to sync to Otto systems.

needed-by #107