### PR TITLE
Restore ContractId to bulk contract response

### DIFF
--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -38,6 +38,7 @@ module Api
 
         def contract_column_names
           columns = %w(
+            ContractId
             CustomerId
             CONT_ContractDate
             CONT_ContractType


### PR DESCRIPTION
Restore ContractId column which is needed. Was accidently
trimmed off of the bulk contract response.

needed-by #107