### PR TITLE
Use pick up orders contract id for bulk contracts

### DIFF
--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -38,7 +38,6 @@ module Api
 
         def contract_column_names
           columns = %w(
-            ContractId
             CustomerId
             CONT_ContractDate
             CONT_ContractType
@@ -53,6 +52,7 @@ module Api
 
         def pick_up_order_column_names
           columns = %w(
+            ContractId
             ItemId
             Origin
             OriginState


### PR DESCRIPTION
The pick up order contract id is in the correct format to send
to Otto. Was using the Contract's but it includes the
contract_type of P which we don't want.

needed-by #107