### PR TITLE
Add load number from pick up order to bulk contract response

### DIFF
--- a/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
+++ b/app/controllers/api/v1/commodity_merchandising/bulk_contracts_controller.rb
@@ -54,6 +54,7 @@ module Api
           columns = %w(
             ContractId
             ItemId
+            LoadNumber
             Origin
             OriginState
             PickupType


### PR DESCRIPTION
Load number is needed because the contract_id + load_number is the
unique number of the pick up order. The release number is an
alias for that pick up order in Grossman.

needed-by #107