### PR TITLE
Allow 1 to 6 digit Grossman order numbers

### DIFF
--- a/app/models/order_query.rb
+++ b/app/models/order_query.rb
@@ -4,7 +4,7 @@ class OrderQuery
   attr_accessor :warehouse_id_eq, :order_number_eq
 
   validates! :warehouse_id_eq, length: { maximum: 4, minimum: 1 }
-  validates! :order_number_eq, length: { is: 6 }
+  validates! :order_number_eq, length: { maximum: 6, minimum: 1 }
 
   def to_ransack_query
     valid? # This will trigger an exception if parameters are missing or invalid

--- a/spec/models/order_query_spec.rb
+++ b/spec/models/order_query_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe OrderQuery, type: :model do
       end
     end
 
-    context 'when order_number_eq is 3 characters long' do
-      let(:order_number_eq) { '123' }
+    context 'when order_number_eq is 7 characters long' do
+      let(:order_number_eq) { '1234567' }
 
       it do
         expect { subject }.to raise_error(ActiveModel::StrictValidationFailed)


### PR DESCRIPTION
Grossman order numbers rolled over. Previously they were always
6 digits but now they can be 1 through 6. Change validations to
allow this.

needed-by #116